### PR TITLE
Remove word_limit

### DIFF
--- a/evals/conf/prompt/meta_level/minimal.yaml
+++ b/evals/conf/prompt/meta_level/minimal.yaml
@@ -1,7 +1,6 @@
 method: meta_level/minimal
 base_prompt: object_level/minimal
 
-word_limit: 1
 messages:
   - role: "system"
     content: |

--- a/evals/conf/prompt/object_level/minimal.yaml
+++ b/evals/conf/prompt/object_level/minimal.yaml
@@ -1,5 +1,4 @@
 method: "object_level/minimal"
-word_limit: 1
 # task.prompt has to contain `$string`
 messages:
   - role: "system"

--- a/evals/conf/prompt/property_extraction/minimal.yaml
+++ b/evals/conf/prompt/property_extraction/minimal.yaml
@@ -1,5 +1,4 @@
 method: "property-extraction-minimal"
-word_limit: 1
 # response_property.property_extraction_prompt has to contain `$response`
 messages:
   - role: "system"


### PR DESCRIPTION
It seems to be unused, and also seems to not align with what we want in general.

Removing it prevents a future change in behavior from tripping up current scripts.