### PR TITLE
Pass `quoting=csv.QUOTE_ALL` to `pd.to_csv`

### DIFF
--- a/evals/create_finetuning_dataset.py
+++ b/evals/create_finetuning_dataset.py
@@ -1,6 +1,7 @@
 """This file is used to find initial completions which are hard to predict."""
 
 import copy
+import csv
 import logging
 import os
 import random
@@ -210,8 +211,8 @@ def generate_single_config_dataset(cfg: DictConfig, train_filepath: Path, val_fi
             f.write("\n")
 
     # save out the dfs so we can recover the split
-    train_df.to_csv(train_filepath.with_suffix(".df.csv"), index=False)
-    val_df.to_csv(val_filepath.with_suffix(".df.csv"), index=False)
+    train_df.to_csv(train_filepath.with_suffix(".df.csv"), index=False, quoting=csv.QUOTE_ALL)
+    val_df.to_csv(val_filepath.with_suffix(".df.csv"), index=False, quoting=csv.QUOTE_ALL)
 
     LOGGER.info(
         f"Saved {len(train_df)} training rows to {train_filepath} & {len(val_df)} validation rows to {val_filepath}"

--- a/evals/extract_model_divergent_strings.py
+++ b/evals/extract_model_divergent_strings.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import subprocess
 import sys
@@ -67,7 +68,7 @@ def extract_most_uncertain_strings_from_base(
     output_file_path = Path(output_file_path)
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    out_df[["string"]].to_csv(output_file_path, index=False)
+    out_df[["string"]].to_csv(output_file_path, index=False, quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Saved {len(out_df)} strings to {output_file_path}")
     return output_file_path
 

--- a/evals/extract_strings_from_dataframe.py
+++ b/evals/extract_strings_from_dataframe.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import subprocess
 import sys
@@ -71,7 +72,7 @@ def extract_strings(input_file_paths, n_out_strings=float("inf"), output_file_pa
     # ensure output dir exists
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    out_df[["string"]].to_csv(output_file_path, index=False)
+    out_df[["string"]].to_csv(output_file_path, index=False, quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Saved {len(out_df)} strings to {output_file_path}")
     return output_file_path
 
@@ -85,8 +86,8 @@ def train_val_split(full_string_path: Path, split: float = 0.2, seed: int = 0):
     train = strings.drop(val.index)
     val_path = full_string_path.parent / ("val_" + full_string_path.name)
     train_path = full_string_path.parent / ("train_" + full_string_path.name)
-    val.to_csv(val_path, index=False)
-    train.to_csv(train_path, index=False)
+    val.to_csv(val_path, index=False, quoting=csv.QUOTE_ALL)
+    train.to_csv(train_path, index=False, quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Saved {n_val} validation strings to {val_path}")
     LOGGER.info(f"Saved {n_train} train strings to {train_path}")
     return val_path, train_path

--- a/evals/extract_token_divergent_strings.py
+++ b/evals/extract_token_divergent_strings.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import subprocess
 import sys
@@ -58,7 +59,7 @@ def extract_most_uncertain_strings_from_base(
     # ensure output dir exists
     output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    out_df[["id", "string"]].to_csv(output_file_path, index=False)
+    out_df[["id", "string"]].to_csv(output_file_path, index=False, quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Saved {len(out_df)} strings to {output_file_path}")
     return output_file_path
 

--- a/evals/generate_few_shot.py
+++ b/evals/generate_few_shot.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import random
 from pathlib import Path
@@ -130,7 +131,7 @@ def generate_few_shot_data(
     else:
         output_file_path = output_path
         assert output_file_path.suffix == ".csv", "Output file must be a .csv file"
-    out_df.to_csv(output_file_path, index=False)
+    out_df.to_csv(output_file_path, index=False, quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Saved {len(out_df)} strings with few-shot completions to {output_file_path}")
     return output_file_path
 

--- a/evals/load/load_dataset.py
+++ b/evals/load/load_dataset.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 from pathlib import Path
 from typing import Optional
@@ -74,4 +75,4 @@ def create_data_file(data: pd.DataFrame, path: str | Path) -> None:
     if not path.suffix == ".csv":
         LOGGER.warning(f"Data file should be a .csv file. Got {path.suffix} instead. Appending...")
         path = path.with_suffix(".csv")
-    data.to_csv(path, index=False)
+    data.to_csv(path, index=False, quoting=csv.QUOTE_ALL)

--- a/evals/run_meta_level.py
+++ b/evals/run_meta_level.py
@@ -1,6 +1,7 @@
 """This is used to run the self prediction task."""
 
 import asyncio
+import csv
 import logging
 import traceback
 from pathlib import Path
@@ -169,7 +170,7 @@ async def run_dataset(filename: str, dataset_runner: DatasetRunner, limit: int =
         )
     )
     full_df.update(df)
-    full_df.to_csv(filename, index=False, encoding="utf-8")
+    full_df.to_csv(filename, index=False, encoding="utf-8", quoting=csv.QUOTE_ALL)
 
     # return whether all rows are complete
     if full_df["complete"].eq(True).all():

--- a/evals/run_object_level.py
+++ b/evals/run_object_level.py
@@ -1,6 +1,7 @@
 """This file is used to find initial completions which are hard to predict."""
 
 import asyncio
+import csv
 import logging
 import shutil
 import traceback
@@ -132,7 +133,7 @@ async def run_dataset(filename: str, dataset_runner: DatasetRunner, limit: Optio
         )
     )
     full_df.update(df)
-    full_df.to_csv(filename, index=False, encoding="utf-8")
+    full_df.to_csv(filename, index=False, encoding="utf-8", quoting=csv.QUOTE_ALL)
 
     # return whether all rows are complete
     if full_df["complete"].eq(True).all():

--- a/evals/run_property_extraction.py
+++ b/evals/run_property_extraction.py
@@ -1,6 +1,7 @@
 """This file is used to use an LLM to extract properties from object-level responses."""
 
 import asyncio
+import csv
 import logging
 import traceback
 from pathlib import Path
@@ -139,7 +140,7 @@ async def run_dataset(filename: str, property_name: str, dataset_runner: Dataset
         )
     )
     full_df.update(df)
-    full_df.to_csv(filename, index=False, encoding="utf-8")
+    full_df.to_csv(filename, index=False, encoding="utf-8", quoting=csv.QUOTE_ALL)
 
     # return whether all rows are complete
     if full_df[f"{property_name}_complete"].eq(True).all():
@@ -205,7 +206,7 @@ def apply_python_function(response_property: DictConfig, filepath: str):
     # apply the function
     df[response_property.name] = df.apply(lambda row: try_function(function, row), axis=1)
     # save the dataset
-    df.to_csv(filepath, index=False, encoding="utf-8")
+    df.to_csv(filepath, index=False, encoding="utf-8", quoting=csv.QUOTE_ALL)
     LOGGER.info(f"Applied python function {response_property.python_function} to {filepath}")
 
 


### PR DESCRIPTION
This prevents errors such as
```
ParserError: Error tokenizing data. C error: Buffer overflow caught - possible malformed input file.
```
when reading csv files that were written with data that contains `\r` when `os.sep` is `'\n'`.