### PR TITLE
added option (on by default) to ensure that all input strings in the finetuning dataset only show up once, even when using other response properties.

### DIFF
--- a/evals/conf/config_finetuning_dataset.yaml
+++ b/evals/conf/config_finetuning_dataset.yaml
@@ -27,6 +27,7 @@ train_base_dir: ?? # the folder of the object level responses to use for trainin
 n_train_items: 500 # number of strings to use in train set. Use `~` to use all strings in the train set.
 val_base_dir: ~ # the folder of the object level responses to use for validation. Use `~` to not use a val set. Should be generated with `task.set = val`.
 n_val_items: 100 # number of strings to use in val set. Use `~` to use all strings in the val set.
+enforce_unique_strings: true # if true, the strings in each set will be unique, even if different response properties are requested. 
 
 train_strings_path: ~ # if set, filter the strings from the train_base_dir with this file
 val_strings_path: ~ # if set, filter the strings from the val_base_dir with this file

--- a/evals/create_finetuning_dataset.py
+++ b/evals/create_finetuning_dataset.py
@@ -4,6 +4,7 @@ import copy
 import csv
 import logging
 import os
+import json
 import random
 import shutil
 from pathlib import Path
@@ -23,6 +24,7 @@ from evals.data_models.messages import ChatMessage, MessageRole, Prompt, PromptT
 from evals.load.lazy_object_level_llm_extraction import (
     lazy_add_response_property_to_object_level,
 )
+from evals.locations import EXP_DIR
 
 CONFIG_PATH = "conf"
 
@@ -99,7 +101,12 @@ def generate_finetuning_jsonl(main_cfg: DictConfig, path: Path, filename: str = 
             with open(val_filepath, "r") as infile:
                 outfile.write(infile.read())
 
-    LOGGER.info(f"Generated {len(train_filepaths)} datasets and saved to {train_filepath} & {val_filepath}")
+    if cfg.enforce_unique_strings:
+        LOGGER.info("Enforcing unique strings.")
+        enforce_unique_strings(path / ("train_" + filename))
+        enforce_unique_strings(path / ("val_" + filename))
+
+    LOGGER.info(f"Generated {len(train_filepaths)} datasets and saved to {train_filepath.relative_to(EXP_DIR)} & {val_filepath.relative_to(EXP_DIR)}")
     return train_filepath, val_filepath
 
 
@@ -199,7 +206,11 @@ def generate_single_config_dataset(cfg: DictConfig, train_filepath: Path, val_fi
         for i, row in tqdm.tqdm(train_df.iterrows(), total=len(train_df), desc="Generating train messages"):
             try:
                 prompt = process_prompt(row, prompt_template, cfg.response_property.name)
-                f.write(prompt.openai_finetuning_format())  # this might not work—use different format if it complains
+                prompt = prompt.openai_finetuning_format()
+                prompt = json.loads(prompt)
+                # add in string to the prompt
+                prompt["string"] = row["string"]
+                f.write(json.dumps(prompt))
                 f.write("\n")
             except ValidationError as e:
                 LOGGER.warning(f"Failed row {i} with error {e}")
@@ -207,7 +218,11 @@ def generate_single_config_dataset(cfg: DictConfig, train_filepath: Path, val_fi
     with open(val_filepath, "a") as f:
         for i, row in tqdm.tqdm(val_df.iterrows(), total=len(val_df), desc="Generating validation messages"):
             prompt = process_prompt(row, prompt_template, cfg.response_property.name)
-            f.write(prompt.openai_finetuning_format())
+            prompt = prompt.openai_finetuning_format()
+            prompt = json.loads(prompt)
+            # add in string to the prompt
+            prompt["string"] = row["string"]
+            f.write(json.dumps(prompt))
             f.write("\n")
 
     # save out the dfs so we can recover the split
@@ -292,6 +307,41 @@ def scramble_strings(df: pd.DataFrame, seed: int) -> pd.DataFrame:
         df[col] = df[col].iloc[shuffled_indices].values
 
     return df
+
+def enforce_unique_strings(path_to_jsonl, random_seed=0):
+    """Enforces that each string in the .jsonl is unique, even if it comes from a different original config. If multiple strings are present, it will randomly select one of them.
+    """
+    with open(path_to_jsonl, "r") as f:
+        lines = f.readlines()
+
+    # get all the strings
+    strings = [json.loads(line)["string"] for line in lines]
+
+    # get the unique strings
+    unique_strings = list(set(strings))
+
+    LOGGER.info(f"Enforcing unique strings on {path_to_jsonl.relative_to(EXP_DIR)}. Found {len(strings)} strings and {len(unique_strings)} unique strings.")
+
+    # create a mapping from the unique strings to the original strings
+    string_mapping = {unique_string: [] for unique_string in unique_strings}
+    for line in lines:
+        data = json.loads(line)
+        string_mapping[data["string"]].append(data)
+
+    # now we have to randomly select one of the strings
+    random.seed(random_seed)
+    new_lines = []
+    for unique_string in unique_strings:
+        data = random.choice(string_mapping[unique_string])
+        new_lines.append(json.dumps(data))
+
+    # write out the new file
+    with open(path_to_jsonl, "w") as f:
+        for line in new_lines:
+            f.write(line)
+            f.write("\n")
+    
+    LOGGER.info(f"Enforced unique strings on {path_to_jsonl.relative_to(EXP_DIR)}. {len(new_lines)} lines written, down from {len(lines)}.")
 
 
 @hydra.main(version_base=None, config_path=CONFIG_PATH, config_name="config_finetuning_dataset")

--- a/scripts/sweep_full_study.py
+++ b/scripts/sweep_full_study.py
@@ -120,13 +120,13 @@ class StudyRunner:
             default="",
         )
         parser.add_argument(
-            "--n_object_train", type=int, help="Number of object level completions for training.", default=10000
+            "--n_object_train", type=int, help="Number of object level completions for training.", default=2000
         )
         parser.add_argument(
-            "--n_object_val", type=int, help="Number of object level completions for validation.", default=2500
+            "--n_object_val", type=int, help="Number of object level completions for validation.", default=500
         )
         parser.add_argument(
-            "--n_finetuning", type=int, help="Number of finetuning completions to generate.", default=12500
+            "--n_finetuning", type=int, help="Number of finetuning completions to generate.", default=500
         )
         parser.add_argument(
             "--n_meta_val", type=int, help="Number of meta level completions for validation.", default=500


### PR DESCRIPTION
https://constellationberkeley.slack.com/archives/C06B8AKFH27/p1711761039931239:

Another thought I had: when we are doing introspection training, we are doing it by giving the model the meta-level question with the object level answer. For each input, we can ask for a range of properties (eg. identity, was it even, what is the first letter, …) Right now, I construct the finetuning dataset by taking all input strings from eg. the wikipedia dataset for each response property and then adding them to the finetuning dataset. So if we have 4 response properties, the finetuning dataset might contain the same input string from the wikipedia dataset 4 times. My intuition is that this isn’t a problem, but I’m curious what your thoughts are. One failure mode that I could see is that the model memorizes its prediction through the “identity” response property and can use that on subsequent epochs to solve the other response properties (eg. the first letter) by making use of that memory rather than introspection—thereby reducing the pressure to actually learn introspection. We could filter the training data to ensure that each input string only shows up once, so that all response properties have unique input strings (edited) 
6 replies


Tomek Korbak
  16 days ago
It depends what effect sizes we're dealing with, but overall filtering training data to ensure that each input string only shows up once seems more principled.
:+1:
1



Tomek Korbak
  16 days ago
btw has prompt_loss_weight  disappeared from openai api? do people know what's the default now?


Tomek Korbak
  16 days ago
If there's non-zero loss on prompt, then your meta-level finetuning is increasing the likelihood of object-level answer which could potentially give spuriously high prediction capabilities


Felix Binder
  15 days ago
It looks like it has disappeared—it still shows up in the search previews, but on none of the pages—but I couldn’t find anything else.


Felix Binder
  15 days ago
We know that the object-level distribution changes as a result of finetuning, but we would expect it to change even if the finetuning is only done on the output, not the prompt (since we’re changing the weights of the model in a way that touches on eg. predicing the next number). I suppose there’s not a principled way to know if a change in the object level distribution is because it sees the the object-level question in the prompt. My sense is that it might not matter that much: the object-level response (ie. what the next word the model has predicted) is never shown in the prompt anyway, just the input question—so from being trained on just the prompt the model shouldn’t get information about the object-level behavior that we’re scoring it on


Tomek Korbak
  14 days ago
yeah, I agree params change in both cases and that it shouldn’t matter. the worry I had pertains the case when the meta-level prompt contains tokens that occur in object-level responses. this would be a problem if your meta-level question is about the object-level completion verbatim, it’s less of a problem if meta-level question is about some features of object-level completion (eg sentiment). overall, not a huge issue!
